### PR TITLE
Revamp driver checklist workflow and PDF template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,5 @@ VITE_SUPABASE_URL="https://twoj-projekt.supabase.co"
 VITE_SUPABASE_ANON_KEY=""
 # Opcjonalne: folder docelowy w Google Drive (ID katalogu), przekazywany do funkcji Edge
 VITE_GOOGLE_DRIVE_PARENT_FOLDER_ID=""
-# Opcjonalne: identyfikator szablonu PDF w Supabase Storage lub Google Drive wykorzystywany w funkcji Edge
-VITE_CHECKLIST_TEMPLATE_ID=""
+# Opcjonalne: identyfikator szablonu PDF (np. "best-food-checklist" dla wbudowanej zielonej karty)
+VITE_CHECKLIST_TEMPLATE_ID="best-food-checklist"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Androidzie dzięki Capacitorowi.
    VITE_SUPABASE_URL="https://twoj-projekt.supabase.co"
    VITE_SUPABASE_ANON_KEY="twój-klucz-anon"
    VITE_GOOGLE_DRIVE_PARENT_FOLDER_ID="id-folderu-na-dysku"
-   VITE_CHECKLIST_TEMPLATE_ID="opcjonalny-id-szablonu"
+   VITE_CHECKLIST_TEMPLATE_ID="best-food-checklist"
    ```
 2. Zainstaluj zależności (patrz sekcja „Instalacja zależności”).
 3. Uruchom środowisko deweloperskie: `npm run dev` – aplikacja wystartuje pod `http://localhost:5173`.
@@ -177,6 +177,11 @@ Dopasuj polityki do własnego schematu – powyższe są wzorcem startowym.
    ```
    > **Uwaga:** powyższy kod jest szkicem referencyjnym – w zależności od użytych bibliotek możesz potrzebować innej konwersji
    > strumienia PDF na `Uint8Array` w środowisku Deno.
+
+   W repozytorium znajdują się dwa gotowe szablony HTML wykorzystywane przez funkcję:
+
+   - `default-checklist-template.html` – uniwersalny raport z tabelą statusów,
+   - `best-food-checklist.html` – zielona karta inspirowana papierową checklistą (ustaw jako `VITE_CHECKLIST_TEMPLATE_ID=best-food-checklist`).
 2. Ustaw sekrety funkcji (Supabase → Edge Functions → Secrets):
    - `SUPABASE_SERVICE_ROLE_KEY`
    - `GOOGLE_CLIENT_EMAIL`

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  namespace "com.3dhaulage.app"         // <-- zostaw swoją nazwę pakietu
-  compileSdk 34                          // <-- WPROST, bez zmiennych
+  namespace "com.threedhaulage.app"     // <-- zostaw swoją nazwę pakietu
+  compileSdkVersion rootProject.ext.compileSdkVersion
 
   defaultConfig {
-    applicationId "com.3dhaulage.app"    // <-- twoje applicationId
-    minSdk 24
-    targetSdk 34
+    applicationId "com.threedhaulage.app"  // <-- twoje applicationId
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
     versionCode 1
     versionName "1.0"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/threedhaulage/app/MainActivity.java
+++ b/android/app/src/main/java/com/threedhaulage/app/MainActivity.java
@@ -1,4 +1,4 @@
-package com.3dhaulage.app;
+package com.threedhaulage.app;
 
 import com.getcapacitor.BridgeActivity;
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="app_name">3D Haulage</string>
     <string name="title_activity_main">3D Haulage</string>
-    <string name="package_name">com.3dhaulage.app</string>
-    <string name="custom_url_scheme">com.3dhaulage.app</string>
+    <string name="package_name">com.threedhaulage.app</string>
+    <string name="custom_url_scheme">com.threedhaulage.app</string>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,7 +1,7 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
-  appId: 'com.3dhaulage.app',
+  appId: 'com.threedhaulage.app',
   appName: '3D Haulage',
   webDir: 'dist',
   bundledWebRuntime: false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,13 @@ import { DeliveriesPage } from './pages/DeliveriesPage';
 import { FleetPage } from './pages/FleetPage';
 import { DriversPage } from './pages/DriversPage';
 import { DriverProfilePage } from './pages/DriverProfilePage';
+import { DriverDeliveriesPage } from './pages/DriverDeliveriesPage';
 import { LoginPage } from './pages/LoginPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
 
 function App() {
-  const { session, loading, isConfigured } = useSupabase();
+  const { session, loading, isConfigured, userRole } = useSupabase();
+  const isAdmin = userRole === 'admin';
 
   if (!isConfigured) {
     return (
@@ -40,11 +42,23 @@ function App() {
           </ProtectedRoute>
         }
       >
-        <Route index element={<DashboardPage />} />
-        <Route path="deliveries" element={<DeliveriesPage />} />
-        <Route path="fleet" element={<FleetPage />} />
-        <Route path="drivers" element={<DriversPage />} />
-        <Route path="profile" element={<DriverProfilePage />} />
+        {isAdmin ? (
+          <>
+            <Route index element={<DashboardPage />} />
+            <Route path="deliveries" element={<DeliveriesPage />} />
+            <Route path="fleet" element={<FleetPage />} />
+            <Route path="drivers" element={<DriversPage />} />
+            <Route path="profile" element={<DriverProfilePage />} />
+          </>
+        ) : (
+          <>
+            <Route index element={<DriverProfilePage />} />
+            <Route path="profile" element={<DriverProfilePage />} />
+            <Route path="deliveries" element={<DriverDeliveriesPage />} />
+            <Route path="drivers" element={<Navigate to="/" replace />} />
+            <Route path="fleet" element={<Navigate to="/" replace />} />
+          </>
+        )}
       </Route>
       <Route path="*" element={<Navigate to={session ? '/' : '/login'} replace />} />
     </Routes>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,14 +1,7 @@
+import { useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
-import { Truck, Users, Package2, LogOut, ChartLine, X, User } from 'lucide-react';
+import { Truck, Users, Package2, LogOut, ChartLine, X, User, ClipboardList } from 'lucide-react';
 import { useSupabase } from '../contexts/SupabaseContext';
-
-const navigation = [
-  { name: 'Panel główny', to: '/', icon: ChartLine },
-  { name: 'Mój profil', to: '/profile', icon: User },
-  { name: 'Zlecenia', to: '/deliveries', icon: Package2 },
-  { name: 'Flota', to: '/fleet', icon: Truck },
-  { name: 'Kierowcy', to: '/drivers', icon: Users }
-];
 
 interface SidebarProps {
   isOpen: boolean;
@@ -16,7 +9,27 @@ interface SidebarProps {
 }
 
 export function Sidebar({ isOpen, onClose }: SidebarProps) {
-  const { signOut } = useSupabase();
+  const { signOut, userRole } = useSupabase();
+
+  const navigation = useMemo(() => {
+    if (userRole === 'admin') {
+      return [
+        { name: 'Panel główny', to: '/', icon: ChartLine },
+        { name: 'Mój profil', to: '/profile', icon: User },
+        { name: 'Zlecenia', to: '/deliveries', icon: Package2 },
+        { name: 'Flota', to: '/fleet', icon: Truck },
+        { name: 'Kierowcy', to: '/drivers', icon: Users }
+      ];
+    }
+
+    return [
+      { name: 'Start zmiany', to: '/', icon: ClipboardList },
+      { name: 'Raport dzienny', to: '/profile', icon: User },
+      { name: 'Moje zlecenia', to: '/deliveries', icon: Package2 }
+    ];
+  }, [userRole]);
+
+  const panelTitle = userRole === 'admin' ? 'Panel zarządzania' : 'Panel kierowcy';
 
   const navLinks = navigation.map(item => (
     <NavLink
@@ -50,7 +63,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       <aside className="sticky top-0 hidden h-screen w-72 flex-col border-r border-slate-200/70 bg-white/70 backdrop-blur-xl lg:flex">
         <div className="px-6 py-6">
           <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">3D haulage</p>
-          <h1 className="text-xl font-semibold text-slate-900">Panel kierowców</h1>
+          <h1 className="text-xl font-semibold text-slate-900">{panelTitle}</h1>
         </div>
         <nav className="flex-1 space-y-1 px-4">{navLinks}</nav>
         <div className="border-t border-slate-200/70 px-4 py-5">{signOutButton}</div>
@@ -64,7 +77,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
         <div className="flex items-center justify-between">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">3D haulage</p>
-            <h1 className="text-xl font-semibold text-slate-900">Panel kierowców</h1>
+            <h1 className="text-xl font-semibold text-slate-900">{panelTitle}</h1>
           </div>
           <button
             type="button"

--- a/src/contexts/SupabaseContext.tsx
+++ b/src/contexts/SupabaseContext.tsx
@@ -3,16 +3,138 @@ import type { PropsWithChildren } from 'react';
 import type { Session, SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseClient } from '../lib/supabaseClient';
 
+type UserRole = 'admin' | 'driver' | 'unknown';
+
 interface SupabaseContextValue {
   supabase: SupabaseClient | null;
   session: Session | null;
   loading: boolean;
   isConfigured: boolean;
+  userRole: UserRole;
+  isAdmin: boolean;
   signIn: (email: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
 }
 
 const SupabaseContext = createContext<SupabaseContextValue | undefined>(undefined);
+
+function matchRoleFromString(value: string): UserRole | null {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.includes('admin')) {
+    return 'admin';
+  }
+
+  if (normalized.includes('driver')) {
+    return 'driver';
+  }
+
+  return null;
+}
+
+function detectRoleFromValue(value: unknown, visited: WeakSet<object> = new WeakSet()): UserRole | null {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return matchRoleFromString(String(value));
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const role = detectRoleFromValue(entry, visited);
+      if (role) {
+        return role;
+      }
+    }
+    return null;
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (visited.has(record)) {
+      return null;
+    }
+    visited.add(record);
+
+    for (const [key, nestedValue] of Object.entries(record)) {
+      const keyLower = key.toLowerCase();
+
+      if (typeof nestedValue === 'boolean' && nestedValue) {
+        if (keyLower.includes('admin')) {
+          return 'admin';
+        }
+        if (keyLower.includes('driver')) {
+          return 'driver';
+        }
+      }
+
+      if (
+        keyLower.includes('role') ||
+        keyLower.includes('account_type') ||
+        keyLower.includes('accounttype') ||
+        keyLower.includes('user_role') ||
+        keyLower.includes('userrole')
+      ) {
+        const nestedRole = detectRoleFromValue(nestedValue, visited);
+        if (nestedRole) {
+          return nestedRole;
+        }
+      }
+    }
+
+    for (const nestedValue of Object.values(record)) {
+      const nestedRole = detectRoleFromValue(nestedValue, visited);
+      if (nestedRole) {
+        return nestedRole;
+      }
+    }
+  }
+
+  return null;
+}
+
+function resolveUserRole(session: Session | null): UserRole {
+  if (!session?.user) {
+    return 'unknown';
+  }
+
+  const appMetadata = (session.user.app_metadata ?? {}) as Record<string, unknown>;
+  const userMetadata = (session.user.user_metadata ?? {}) as Record<string, unknown>;
+
+  const metadataCandidates: unknown[] = [
+    appMetadata['role'],
+    appMetadata['roles'],
+    appMetadata['user_role'],
+    appMetadata['userRole'],
+    userMetadata['role'],
+    userMetadata['roles'],
+    userMetadata['account_type'],
+    userMetadata['accountType']
+  ];
+
+  for (const candidate of metadataCandidates) {
+    const resolved = detectRoleFromValue(candidate);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  const metadataSources: unknown[] = [appMetadata, userMetadata];
+
+  for (const source of metadataSources) {
+    const resolved = detectRoleFromValue(source);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return 'unknown';
+}
 
 export function SupabaseProvider({ children }: PropsWithChildren) {
   const [supabase] = useState(() => createSupabaseClient());
@@ -66,11 +188,15 @@ export function SupabaseProvider({ children }: PropsWithChildren) {
       await supabase.auth.signOut();
     };
 
+    const userRole = resolveUserRole(session);
+
     return {
       supabase,
       session,
       loading,
       isConfigured,
+      userRole,
+      isAdmin: userRole === 'admin',
       signIn,
       signOut
     } satisfies SupabaseContextValue;

--- a/src/hooks/useDriverProfile.ts
+++ b/src/hooks/useDriverProfile.ts
@@ -1,0 +1,209 @@
+import { useQuery } from '@tanstack/react-query';
+import type { PostgrestError } from '@supabase/supabase-js';
+import { useSupabase } from '../contexts/SupabaseContext';
+import type { Session } from '@supabase/supabase-js';
+import type { DriverProfile } from '../types/driver';
+
+function isMissingRelation(error: PostgrestError) {
+  return error.code === '42P01' || /relation .+ does not exist/i.test(error.message);
+}
+
+function isPermissionDenied(error: PostgrestError) {
+  return error.code === '42501' || /permission denied/i.test(error.message);
+}
+
+function isMissingColumn(error: PostgrestError) {
+  return error.code === '42703' || /column .+ does not exist/i.test(error.message);
+}
+
+function pickString(values: unknown[], fallback: string | null = null): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length) {
+      return value.trim();
+    }
+  }
+  return fallback;
+}
+
+function createProfileFromSession(session: Session | null): DriverProfile | null {
+  if (!session?.user) {
+    return null;
+  }
+
+  const metadata = (session.user.user_metadata ?? {}) as Record<string, unknown>;
+  const nestedDriver = metadata.driver as Record<string, unknown> | undefined;
+
+  const fullName =
+    pickString([
+      metadata.full_name,
+      metadata.fullName,
+      metadata.name,
+      nestedDriver?.full_name,
+      nestedDriver?.name
+    ]) ?? session.user.email ?? 'Kierowca';
+
+  const driverId = pickString([
+    metadata.driver_id,
+    metadata.driverId,
+    nestedDriver?.id
+  ]);
+
+  return {
+    id:
+      pickString([
+        metadata.profile_id,
+        metadata.profileId,
+        nestedDriver?.profile_id,
+        nestedDriver?.id
+      ]) ?? session.user.id,
+    user_id: session.user.id,
+    driver_id: driverId ?? null,
+    full_name: fullName,
+    phone:
+      pickString([
+        metadata.phone,
+        metadata.phone_number,
+        metadata.phoneNumber,
+        nestedDriver?.phone
+      ]) ?? null,
+    license_number:
+      pickString([
+        metadata.license_number,
+        metadata.licenseNumber,
+        nestedDriver?.license_number
+      ]) ?? null,
+    avatar_url:
+      pickString([
+        metadata.avatar_url,
+        metadata.avatar,
+        nestedDriver?.avatar_url
+      ]) ?? null,
+    home_depot:
+      pickString([
+        metadata.home_depot,
+        metadata.depot,
+        nestedDriver?.home_depot
+      ]) ?? null
+  };
+}
+
+function normaliseProfileRecord(
+  record: Record<string, unknown>,
+  fallback: DriverProfile | null,
+  session: Session | null
+): DriverProfile {
+  const nestedDriver = record.driver as Record<string, unknown> | undefined;
+
+  const fullName =
+    pickString(
+      [
+        record.full_name,
+        record.fullName,
+        record.name,
+        nestedDriver?.full_name,
+        nestedDriver?.name,
+        fallback?.full_name
+      ],
+      session?.user?.email ?? 'Kierowca'
+    ) ?? 'Kierowca';
+
+  return {
+    id:
+      pickString(
+        [
+          record.id,
+          record.profile_id,
+          record.profileId,
+          nestedDriver?.id,
+          fallback?.id,
+          session?.user?.id ?? null
+        ],
+        session?.user?.id ?? undefined
+      ) ?? (session?.user?.id ?? ''),
+    user_id:
+      pickString([record.user_id, record.userId, fallback?.user_id, session?.user?.id]) ??
+      (session?.user?.id ?? ''),
+    driver_id:
+      pickString([
+        record.driver_id,
+        record.driverId,
+        nestedDriver?.id,
+        fallback?.driver_id
+      ]) ?? null,
+    full_name: fullName,
+    phone:
+      pickString([
+        record.phone,
+        record.phone_number,
+        record.phoneNumber,
+        nestedDriver?.phone,
+        fallback?.phone
+      ]) ?? null,
+    license_number:
+      pickString([
+        record.license_number,
+        record.licenseNumber,
+        record.licence_number,
+        nestedDriver?.license_number,
+        fallback?.license_number
+      ]) ?? null,
+    avatar_url:
+      pickString([
+        record.avatar_url,
+        record.avatar,
+        nestedDriver?.avatar_url,
+        fallback?.avatar_url
+      ]) ?? null,
+    home_depot:
+      pickString([
+        record.home_depot,
+        record.depot,
+        record.base,
+        nestedDriver?.home_depot,
+        fallback?.home_depot
+      ]) ?? null
+  };
+}
+
+export function useDriverProfile() {
+  const { supabase, session } = useSupabase();
+
+  return useQuery<DriverProfile | null>({
+    enabled: Boolean(supabase && session?.user?.id),
+    queryKey: ['driver-profile', session?.user?.id],
+    queryFn: async () => {
+      if (!supabase || !session?.user?.id) {
+        return null;
+      }
+
+      const sessionFallback = createProfileFromSession(session);
+
+      const candidateSources = [
+        { table: 'driver_profiles_view', columns: 'id, user_id, driver_id, full_name, phone, license_number, avatar_url, home_depot' },
+        { table: 'driver_profiles', columns: '*' },
+        { table: 'profiles', columns: '*' }
+      ] as const;
+
+      for (const source of candidateSources) {
+        const { data, error } = await supabase
+          .from(source.table)
+          .select(source.columns)
+          .eq('user_id', session.user.id)
+          .maybeSingle();
+
+        if (error) {
+          if (isMissingRelation(error) || isMissingColumn(error) || isPermissionDenied(error)) {
+            continue;
+          }
+          throw error;
+        }
+
+        if (data) {
+          return normaliseProfileRecord(data as Record<string, unknown>, sessionFallback, session);
+        }
+      }
+
+      return sessionFallback;
+    }
+  });
+}

--- a/src/lib/driverAssignments.ts
+++ b/src/lib/driverAssignments.ts
@@ -1,0 +1,48 @@
+import type { PostgrestError, SupabaseClient } from '@supabase/supabase-js';
+import type { DriverAssignment } from '../types/driver';
+
+interface FetchDriverAssignmentsOptions {
+  fromDate?: string;
+}
+
+export async function fetchDriverAssignments(
+  supabase: SupabaseClient,
+  driverId: string,
+  { fromDate }: FetchDriverAssignmentsOptions = {}
+) {
+  let query = supabase
+    .from('driver_assignments_view')
+    .select(
+      `id, assignment_date, shift_start, shift_end, depot_name, destination_name, route_name,
+       vehicle:vehicles(id, registration, make, model)`
+    )
+    .eq('driver_id', driverId)
+    .order('assignment_date', { ascending: true });
+
+  if (fromDate) {
+    query = query.gte('assignment_date', fromDate);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    if (isMissingRelation(error) || isMissingColumn(error)) {
+      console.warn('Pomijam brakujący widok driver_assignments_view:', error.message);
+      return [];
+    }
+    throw error;
+  }
+
+  return ((data as DriverAssignment[]) ?? []).map(assignment => ({
+    ...assignment,
+    vehicle: assignment.vehicle ?? null
+  }));
+}
+
+function isMissingRelation(error: PostgrestError) {
+  return error.code === '42P01' || /relation .+ does not exist/i.test(error.message);
+}
+
+function isMissingColumn(error: PostgrestError) {
+  return error.code === '42703' || /column .+ does not exist/i.test(error.message);
+}

--- a/src/pages/DriverDeliveriesPage.tsx
+++ b/src/pages/DriverDeliveriesPage.tsx
@@ -1,0 +1,254 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { CalendarDays, Clock, MapPin, Package2, Route, Truck } from 'lucide-react';
+import { useSupabase } from '../contexts/SupabaseContext';
+import { useDriverProfile } from '../hooks/useDriverProfile';
+import { fetchDriverAssignments } from '../lib/driverAssignments';
+import type { DriverAssignment } from '../types/driver';
+import { LoadingState } from '../components/LoadingState';
+import { ErrorState } from '../components/ErrorState';
+
+export function DriverDeliveriesPage() {
+  const { supabase } = useSupabase();
+  const {
+    data: profile,
+    isLoading: isProfileLoading,
+    error: profileError
+  } = useDriverProfile();
+
+  const driverId = profile?.driver_id ?? profile?.id ?? null;
+
+  const assignmentsQuery = useQuery<DriverAssignment[]>({
+    enabled: Boolean(supabase && driverId),
+    queryKey: ['driver-assignments-list', driverId],
+    queryFn: async () => {
+      if (!supabase || !driverId) {
+        return [];
+      }
+      return fetchDriverAssignments(supabase, driverId);
+    }
+  });
+
+  const today = useMemo(() => dayjs().startOf('day'), []);
+
+  const { upcomingAssignments, pastAssignments } = useMemo(() => {
+    const assignments = assignmentsQuery.data ?? [];
+    const upcoming: DriverAssignment[] = [];
+    const past: DriverAssignment[] = [];
+
+    assignments.forEach(assignment => {
+      const assignmentDate = dayjs(assignment.assignment_date);
+      if (assignmentDate.isBefore(today, 'day')) {
+        past.push(assignment);
+      } else {
+        upcoming.push(assignment);
+      }
+    });
+
+    return {
+      upcomingAssignments: upcoming,
+      pastAssignments: past.reverse()
+    };
+  }, [assignmentsQuery.data, today]);
+
+  if (isProfileLoading || assignmentsQuery.isLoading) {
+    return <LoadingState label="Ładowanie zleceń kierowcy..." />;
+  }
+
+  if (profileError) {
+    return (
+      <ErrorState
+        title="Nie udało się pobrać profilu kierowcy"
+        description={profileError instanceof Error ? profileError.message : undefined}
+      />
+    );
+  }
+
+  if (!profile) {
+    return (
+      <ErrorState
+        title="Brak profilu kierowcy"
+        description="Utwórz rekord w widoku driver_profiles_view powiązany z bieżącym użytkownikiem."
+      />
+    );
+  }
+
+  if (assignmentsQuery.error) {
+    return (
+      <ErrorState
+        title="Nie udało się pobrać listy zleceń"
+        description={assignmentsQuery.error instanceof Error ? assignmentsQuery.error.message : undefined}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-soft">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-900">Moje zlecenia</h1>
+            <p className="text-sm text-slate-500">
+              Przeglądaj wszystkie przydzielone trasy od dyspozytora i śledź zaplanowane wyjazdy.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-flow-col sm:grid-cols-2">
+            <SummaryBadge label="Planowane" value={upcomingAssignments.length} tone="brand" />
+            <SummaryBadge label="Zrealizowane" value={pastAssignments.length} tone="slate" />
+          </div>
+        </div>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <Package2 className="h-5 w-5 text-brand-500" />
+          <h2 className="text-lg font-semibold text-slate-900">Najbliższe zlecenia</h2>
+        </div>
+        {upcomingAssignments.length ? (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {upcomingAssignments.map(assignment => (
+              <AssignmentCard key={assignment.id} assignment={assignment} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState message="Brak zaplanowanych zleceń. Skontaktuj się z dyspozytorem." />
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="h-5 w-5 text-slate-400" />
+          <h2 className="text-lg font-semibold text-slate-900">Zrealizowane trasy</h2>
+        </div>
+        {pastAssignments.length ? (
+          <div className="grid gap-4 xl:grid-cols-2">
+            {pastAssignments.map(assignment => (
+              <AssignmentCard key={assignment.id} assignment={assignment} variant="past" />
+            ))}
+          </div>
+        ) : (
+          <EmptyState message="Brak zakończonych tras do wyświetlenia." subtle />
+        )}
+      </section>
+    </div>
+  );
+}
+
+interface SummaryBadgeProps {
+  label: string;
+  value: number;
+  tone: 'brand' | 'slate';
+}
+
+function SummaryBadge({ label, value, tone }: SummaryBadgeProps) {
+  return (
+    <div
+      className={`rounded-2xl border px-4 py-3 text-center text-sm font-semibold shadow-sm ${
+        tone === 'brand'
+          ? 'border-brand-200 bg-brand-50 text-brand-700'
+          : 'border-slate-200 bg-white/70 text-slate-600'
+      }`}
+    >
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-400">{label}</p>
+      <p className="text-xl text-current">{value}</p>
+    </div>
+  );
+}
+
+interface EmptyStateProps {
+  message: string;
+  subtle?: boolean;
+}
+
+function EmptyState({ message, subtle = false }: EmptyStateProps) {
+  return (
+    <div
+      className={`rounded-3xl border border-dashed p-6 text-sm ${
+        subtle
+          ? 'border-slate-200 bg-white/60 text-slate-500'
+          : 'border-amber-200 bg-amber-50/80 text-amber-700'
+      }`}
+    >
+      {message}
+    </div>
+  );
+}
+
+interface AssignmentCardProps {
+  assignment: DriverAssignment;
+  variant?: 'default' | 'past';
+}
+
+function AssignmentCard({ assignment, variant = 'default' }: AssignmentCardProps) {
+  const assignmentDate = dayjs(assignment.assignment_date);
+
+  return (
+    <article
+      className={`rounded-3xl border p-6 shadow-soft transition ${
+        variant === 'past'
+          ? 'border-slate-200 bg-white/70'
+          : 'border-brand-200 bg-white/80 hover:border-brand-300 hover:shadow-lg'
+      }`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+            <CalendarDays className="h-4 w-4 text-brand-500" />
+            {assignmentDate.format('dddd, D MMMM YYYY')}
+          </p>
+          <h3 className="mt-1 text-lg font-semibold text-slate-900">
+            {assignment.route_name ?? 'Trasa bez nazwy'}
+          </h3>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold ${
+            variant === 'past'
+              ? 'bg-slate-100 text-slate-500'
+              : 'bg-brand-100 text-brand-700'
+          }`}
+        >
+          {variant === 'past' ? 'Zakończono' : 'Zaplanowano'}
+        </span>
+      </div>
+
+      <dl className="mt-5 grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+        <div className="flex items-center gap-2">
+          <Route className="h-4 w-4 text-brand-500" />
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Start</dt>
+            <dd className="font-medium text-slate-700">{assignment.depot_name ?? '—'}</dd>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <MapPin className="h-4 w-4 rotate-180 text-brand-500" />
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Cel</dt>
+            <dd className="font-medium text-slate-700">{assignment.destination_name ?? '—'}</dd>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Clock className="h-4 w-4 text-brand-500" />
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Godziny</dt>
+            <dd className="font-medium text-slate-700">
+              {assignment.shift_start ?? '—'} - {assignment.shift_end ?? '—'}
+            </dd>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Truck className="h-4 w-4 text-brand-500" />
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Pojazd</dt>
+            <dd className="font-medium text-slate-700">
+              {assignment.vehicle?.registration ?? 'Nie przypisano'}
+            </dd>
+            <p className="text-xs text-slate-400">
+              {[assignment.vehicle?.make, assignment.vehicle?.model].filter(Boolean).join(' ') || 'Dane pojazdu niedostępne'}
+            </p>
+          </div>
+        </div>
+      </dl>
+    </article>
+  );
+}

--- a/src/types/driver.ts
+++ b/src/types/driver.ts
@@ -1,0 +1,51 @@
+export interface DriverProfile {
+  id: string;
+  user_id: string;
+  driver_id?: string | null;
+  full_name: string;
+  phone?: string | null;
+  license_number?: string | null;
+  avatar_url?: string | null;
+  home_depot?: string | null;
+}
+
+export interface VehicleSummary {
+  id: string;
+  registration?: string | null;
+  make?: string | null;
+  model?: string | null;
+}
+
+export interface DriverAssignment {
+  id: string;
+  assignment_date: string;
+  shift_start?: string | null;
+  shift_end?: string | null;
+  depot_name?: string | null;
+  destination_name?: string | null;
+  route_name?: string | null;
+  vehicle?: VehicleSummary | null;
+}
+
+export type ChecklistItemValue = 'ok' | 'attention' | 'na';
+
+export type ChecklistState = Record<string, ChecklistItemValue | boolean>;
+
+export interface DriverDailyReport {
+  id: string;
+  assignment_id: string;
+  driver_id?: string | null;
+  start_odometer?: number | null;
+  fuel_level?: number | null;
+  notes?: string | null;
+  checklist_state?: ChecklistState | null;
+  completed_at?: string | null;
+  drive_file_url?: string | null;
+  drive_file_id?: string | null;
+}
+
+export interface ChecklistPdfResponse {
+  drive_file_id?: string | null;
+  drive_file_url?: string | null;
+  file_name?: string | null;
+}

--- a/supabase/functions/generate-checklist-report/templates/best-food-checklist.html
+++ b/supabase/functions/generate-checklist-report/templates/best-food-checklist.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="pl">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Raport kontroli pojazdu</title>
+    <style>
+      body {
+        font-family: 'Helvetica', 'Arial', sans-serif;
+        background: #d4efc5;
+        color: #0b3d2e;
+        margin: 0;
+        padding: 36px;
+      }
+      .sheet {
+        background: #f1f8ec;
+        border: 2px solid #0b3d2e;
+        box-shadow: 0 12px 30px rgba(11, 61, 46, 0.15);
+        padding: 28px 32px;
+      }
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        border-bottom: 2px solid #0b3d2e;
+        padding-bottom: 16px;
+        margin-bottom: 20px;
+      }
+      header h1 {
+        font-size: 22px;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        margin: 0;
+      }
+      header span.subtle {
+        display: block;
+        margin-top: 6px;
+        font-size: 12px;
+        color: #1a5c45;
+      }
+      .meta-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 20px;
+        font-size: 13px;
+      }
+      .meta-table th,
+      .meta-table td {
+        border: 1px solid rgba(11, 61, 46, 0.4);
+        padding: 8px 10px;
+        background: rgba(255, 255, 255, 0.7);
+      }
+      .meta-table th {
+        width: 25%;
+        text-transform: uppercase;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-align: left;
+        color: #0b3d2e;
+      }
+      .checklist-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+        margin-bottom: 18px;
+      }
+      .checklist-table th,
+      .checklist-table td {
+        border: 1px solid rgba(11, 61, 46, 0.35);
+        padding: 7px 8px;
+        background: rgba(255, 255, 255, 0.6);
+      }
+      .checklist-table thead th {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: rgba(11, 61, 46, 0.12);
+      }
+      .checklist-table td.status {
+        width: 50px;
+        text-align: center;
+        font-weight: 700;
+        font-size: 14px;
+      }
+      .section-heading {
+        background: rgba(11, 61, 46, 0.2);
+        font-weight: 700;
+        text-transform: uppercase;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        padding: 6px 10px;
+      }
+      .defects-box,
+      .notes-box {
+        border: 1px dashed rgba(11, 61, 46, 0.6);
+        background: rgba(255, 255, 255, 0.65);
+        padding: 12px;
+        margin-bottom: 16px;
+        min-height: 70px;
+        font-size: 12px;
+        line-height: 1.45;
+      }
+      footer {
+        border-top: 1px solid rgba(11, 61, 46, 0.3);
+        padding-top: 10px;
+        font-size: 10px;
+        text-align: right;
+        color: #1a5c45;
+      }
+      .signature-row {
+        display: flex;
+        justify-content: space-between;
+        gap: 24px;
+        margin-top: 24px;
+      }
+      .signature-row .signature {
+        flex: 1;
+        border-top: 1px solid rgba(11, 61, 46, 0.7);
+        text-align: center;
+        padding-top: 6px;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="sheet">
+      <header>
+        <div>
+          <h1>3D Haulage</h1>
+          <span class="subtle">Driver Vehicle Check &amp; Defect Report</span>
+        </div>
+        <div style="text-align: right; font-size: 12px;">
+          <strong>Raport nr:</strong> {{reportNumber}}<br />
+          <strong>Data:</strong> {{checklistDate}}
+        </div>
+      </header>
+
+      <table class="meta-table">
+        <tbody>
+          <tr>
+            <th>Kierowca</th>
+            <td>{{driverName}}{{#driverEmail}}<br /><small>{{driverEmail}}</small>{{/driverEmail}}</td>
+            <th>Pojazd</th>
+            <td>{{vehicleRegistration}}{{#vehicleDescription}}<br /><small>{{vehicleDescription}}</small>{{/vehicleDescription}}</td>
+          </tr>
+          <tr>
+            <th>Baza wyjazdu</th>
+            <td>{{depotName}}</td>
+            <th>Miejsce docelowe</th>
+            <td>{{destinationName}}</td>
+          </tr>
+          <tr>
+            <th>Zmiana</th>
+            <td>{{#shiftWindow}}{{shiftWindow}}{{/shiftWindow}}{{^shiftWindow}}—{{/shiftWindow}}</td>
+            <th>Stan licznika</th>
+            <td>{{odometerStart}}</td>
+          </tr>
+          <tr>
+            <th>Poziom paliwa</th>
+            <td>{{fuelLevel}}</td>
+            <th>Usterki zgłoszone</th>
+            <td>{{defectsCount}}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table class="checklist-table">
+        <thead>
+          <tr>
+            <th>Pozycja kontrolna</th>
+            <th>OK</th>
+            <th>Usterka</th>
+            <th>N/D</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#sections}}
+          <tr>
+            <td colspan="5" class="section-heading">{{title}}</td>
+          </tr>
+          {{#items}}
+          <tr>
+            <td>{{label}}</td>
+            <td class="status">{{#ok}}✔{{/ok}}</td>
+            <td class="status">{{#attention}}⚠{{/attention}}</td>
+            <td class="status">{{#na}}—{{/na}}</td>
+            <td>{{value}}</td>
+          </tr>
+          {{/items}}
+          {{/sections}}
+          {{^sections}}
+          {{#items}}
+          <tr>
+            <td>{{label}}</td>
+            <td class="status"></td>
+            <td class="status"></td>
+            <td class="status"></td>
+            <td>{{value}}</td>
+          </tr>
+          {{/items}}
+          {{^items}}
+          <tr>
+            <td colspan="5">Brak pozycji do wyświetlenia</td>
+          </tr>
+          {{/items}}
+          {{/sections}}
+        </tbody>
+      </table>
+
+      <div class="defects-box">
+        <strong>Usterki do zgłoszenia:</strong><br />
+        {{#defectsCount}}
+        <ul style="margin: 6px 0 0 18px; padding: 0;">
+          {{#defectItems}}
+          <li>{{label}} — {{value}}</li>
+          {{/defectItems}}
+        </ul>
+        {{/defectsCount}}
+        {{^defectsCount}}
+        Brak zgłoszonych usterek.
+        {{/defectsCount}}
+      </div>
+
+      <div class="notes-box">
+        <strong>Uwagi kierowcy:</strong><br />
+        {{notes}}
+      </div>
+
+      <div class="signature-row">
+        <div class="signature">Podpis kierowcy</div>
+        <div class="signature">Podpis przełożonego</div>
+      </div>
+
+      <footer>
+        Raport wygenerowano automatycznie {{generatedAt}} przez system 3D Haulage.
+      </footer>
+    </div>
+  </body>
+</html>

--- a/supabase/functions/generate-checklist-report/templates/default-checklist-template.html
+++ b/supabase/functions/generate-checklist-report/templates/default-checklist-template.html
@@ -28,14 +28,20 @@
         gap: 12px;
         margin-top: 16px;
       }
-      .metadata span {
+      .metadata span,
+      .metadata small {
         display: block;
-        font-size: 14px;
+        font-size: 13px;
         color: #374151;
       }
       .metadata strong {
         font-size: 16px;
         color: #111827;
+      }
+      .metadata small {
+        margin-top: 2px;
+        font-size: 12px;
+        color: #6b7280;
       }
       section {
         margin-bottom: 24px;
@@ -44,29 +50,27 @@
         font-size: 18px;
         margin-bottom: 12px;
       }
-      ul.checklist {
-        list-style: none;
-        padding: 0;
-        margin: 0;
+      table.checklist {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+      }
+      table.checklist th,
+      table.checklist td {
         border: 1px solid #d1d5db;
-        border-radius: 8px;
-        overflow: hidden;
+        padding: 8px 10px;
       }
-      ul.checklist li {
-        display: flex;
-        justify-content: space-between;
-        padding: 10px 14px;
-        border-bottom: 1px solid #e5e7eb;
+      table.checklist th {
+        background-color: #e5e7eb;
+        text-align: left;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
       }
-      ul.checklist li:last-child {
-        border-bottom: none;
-      }
-      ul.checklist li span.label {
+      table.checklist td.status {
+        width: 60px;
+        text-align: center;
         font-weight: 600;
-        color: #111827;
-      }
-      ul.checklist li span.value {
-        color: #1f2937;
       }
       .notes {
         min-height: 100px;
@@ -96,6 +100,9 @@
         <div>
           <span>Pojazd</span>
           <strong>{{vehicleRegistration}}</strong>
+          {{#vehicleDescription}}
+          <small>{{vehicleDescription}}</small>
+          {{/vehicleDescription}}
         </div>
         <div>
           <span>Data kontroli</span>
@@ -105,25 +112,91 @@
           <span>Numer raportu</span>
           <strong>{{reportNumber}}</strong>
         </div>
+        <div>
+          <span>Odo start</span>
+          <strong>{{odometerStart}}</strong>
+        </div>
+        <div>
+          <span>Paliwo</span>
+          <strong>{{fuelLevel}}</strong>
+        </div>
+        <div>
+          <span>Baza / Cel</span>
+          <strong>{{depotName}} → {{destinationName}}</strong>
+          {{#shiftWindow}}
+          <small>Zmiana: {{shiftWindow}}</small>
+          {{/shiftWindow}}
+        </div>
       </div>
     </header>
 
+    {{#sections}}
+    <section>
+      <h2>{{title}}</h2>
+      <table class="checklist">
+        <thead>
+          <tr>
+            <th>Pozycja</th>
+            <th>OK</th>
+            <th>Usterka</th>
+            <th>N/D</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#items}}
+          <tr>
+            <td>{{label}}</td>
+            <td class="status">{{#ok}}✔{{/ok}}</td>
+            <td class="status">{{#attention}}⚠{{/attention}}</td>
+            <td class="status">{{#na}}—{{/na}}</td>
+            <td>{{value}}</td>
+          </tr>
+          {{/items}}
+        </tbody>
+      </table>
+    </section>
+    {{/sections}}
+
+    {{^sections}}
     <section>
       <h2>Lista kontrolna</h2>
-      <ul class="checklist">
-        {{#items}}
-        <li>
-          <span class="label">{{label}}</span>
-          <span class="value">{{value}}</span>
-        </li>
-        {{/items}}
-        {{^items}}
-        <li>
-          <span class="label">Brak pozycji</span>
-          <span class="value">-</span>
-        </li>
-        {{/items}}
+      <table class="checklist">
+        <thead>
+          <tr>
+            <th>Pozycja</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#items}}
+          <tr>
+            <td>{{label}}</td>
+            <td>{{value}}</td>
+          </tr>
+          {{/items}}
+          {{^items}}
+          <tr>
+            <td colspan="2">Brak pozycji</td>
+          </tr>
+          {{/items}}
+        </tbody>
+      </table>
+    </section>
+    {{/sections}}
+
+    <section>
+      <h2>Wykryte usterki</h2>
+      {{#defectsCount}}
+      <ul>
+        {{#defectItems}}
+        <li>{{label}} — {{value}}</li>
+        {{/defectItems}}
       </ul>
+      {{/defectsCount}}
+      {{^defectsCount}}
+      <p>Brak zgłoszonych usterek.</p>
+      {{/defectsCount}}
     </section>
 
     <section>


### PR DESCRIPTION
## Summary
- add resilient Supabase profile/assignment lookups that fall back to session metadata when views are missing
- redesign the driver profile checklist with rich status selectors, Google Drive payloads, and assignment/defect summaries
- extend the checklist PDF generator with structured sections plus a Best Food style template and updated documentation/env defaults

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cdc4e1c28483249701bc0ae1351ccc