### PR TITLE
Fix StatusBadge normalization for empty statuses

### DIFF
--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -30,8 +30,13 @@ interface StatusBadgeProps {
 }
 
 export function StatusBadge({ status }: StatusBadgeProps) {
-  const normalizedStatus = (status?.toLowerCase().replace(/\s+/g, '_') as Status) ?? 'planned';
-  const fallback = statusMap.planned;
+  const fallbackStatus: Status = 'planned';
+  const rawStatus = (status ?? '').trim();
+  const normalizedStatus = rawStatus
+    ? (rawStatus.toLowerCase().replace(/\s+/g, '_') as Status)
+    : fallbackStatus;
+
+  const fallback = statusMap[fallbackStatus];
   const { label, className } = statusMap[normalizedStatus] ?? fallback;
 
   return (


### PR DESCRIPTION
## Summary
- ensure StatusBadge normalizes statuses using a safe string fallback
- default to the planned badge when status is missing or empty to avoid runtime errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d01539d330832492f2bce8ca7692d4