### PR TITLE
Update driver checklist branding to 3DHaulage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 3D Haulage Driver Portal
+# 3DHaulage Driver Portal
 
 Nowoczesny, responsywny panel webowy działający na wspólnej bazie Supabase wykorzystywanej przez aplikację KierowcaApp. Projekt
 udostępnia komplet narzędzi dla dyspozytorów i kierowców – od monitoringu floty po codzienną checklistę, która automatycznie
@@ -31,7 +31,7 @@ Androidzie dzięki Capacitorowi.
    VITE_SUPABASE_URL="https://twoj-projekt.supabase.co"
    VITE_SUPABASE_ANON_KEY="twój-klucz-anon"
    VITE_GOOGLE_DRIVE_PARENT_FOLDER_ID="id-folderu-na-dysku"
-   VITE_CHECKLIST_TEMPLATE_ID="best-food-checklist"
+   VITE_CHECKLIST_TEMPLATE_ID="3dhaulage-checklist"
    ```
 2. Zainstaluj zależności (patrz sekcja „Instalacja zależności”).
 3. Uruchom środowisko deweloperskie: `npm run dev` – aplikacja wystartuje pod `http://localhost:5173`.
@@ -181,7 +181,7 @@ Dopasuj polityki do własnego schematu – powyższe są wzorcem startowym.
    W repozytorium znajdują się dwa gotowe szablony HTML wykorzystywane przez funkcję:
 
    - `default-checklist-template.html` – uniwersalny raport z tabelą statusów,
-   - `best-food-checklist.html` – zielona karta inspirowana papierową checklistą (ustaw jako `VITE_CHECKLIST_TEMPLATE_ID=best-food-checklist`).
+   - `3dhaulage-checklist.html` – zielona karta inspirowana papierową checklistą (ustaw jako `VITE_CHECKLIST_TEMPLATE_ID=3dhaulage-checklist`).
 2. Ustaw sekrety funkcji (Supabase → Edge Functions → Secrets):
    - `SUPABASE_SERVICE_ROLE_KEY`
    - `GOOGLE_CLIENT_EMAIL`
@@ -253,4 +253,4 @@ src/
 - Zaimplementuj powiadomienia push (Firebase Cloud Messaging) dzięki Capacitor Push Notifications.
 - Rozważ włączenie testów E2E (Playwright/Cypress) dla krytycznych scenariuszy.
 
-Powodzenia w dalszym rozwijaniu platformy 3D Haulage! 🚛
+Powodzenia w dalszym rozwijaniu platformy 3DHaulage! 🚛

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="app_name">3D Haulage</string>
-    <string name="title_activity_main">3D Haulage</string>
+    <string name="app_name">3DHaulage</string>
+    <string name="title_activity_main">3DHaulage</string>
     <string name="package_name">com.threedhaulage.app</string>
     <string name="custom_url_scheme">com.threedhaulage.app</string>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'com.threedhaulage.app',
-  appName: '3D Haulage',
+  appName: '3DHaulage',
   webDir: 'dist',
   bundledWebRuntime: false,
   server: {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>3D Haulage Dashboard</title>
+    <title>3DHaulage Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -23,7 +23,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     }
 
     return [
-      { name: 'Start zmiany', to: '/', icon: ClipboardList },
+      { name: 'Checklista', to: '/', icon: ClipboardList },
       { name: 'Raport dzienny', to: '/profile', icon: User },
       { name: 'Moje zlecenia', to: '/deliveries', icon: Package2 }
     ];
@@ -62,7 +62,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
     <>
       <aside className="sticky top-0 hidden h-screen w-72 flex-col border-r border-slate-200/70 bg-white/70 backdrop-blur-xl lg:flex">
         <div className="px-6 py-6">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">3D haulage</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">3DHaulage</p>
           <h1 className="text-xl font-semibold text-slate-900">{panelTitle}</h1>
         </div>
         <nav className="flex-1 space-y-1 px-4">{navLinks}</nav>
@@ -76,7 +76,7 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       >
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">3D haulage</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">3DHaulage</p>
             <h1 className="text-xl font-semibold text-slate-900">{panelTitle}</h1>
           </div>
           <button

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -33,7 +33,7 @@ export function TopBar({ onToggleSidebar }: TopBarProps) {
               <Menu className="h-5 w-5" />
             </button>
             <div>
-              <p className="text-xs uppercase tracking-[0.3em] text-brand-600">3D Haulage</p>
+              <p className="text-xs uppercase tracking-[0.3em] text-brand-600">3DHaulage</p>
               <h2 className="mt-1 text-2xl font-semibold text-slate-900">Witamy ponownie!</h2>
               <p className="text-sm text-slate-500">{dayjs().format('dddd, D MMMM YYYY')}</p>
             </div>

--- a/src/pages/DriverProfilePage.tsx
+++ b/src/pages/DriverProfilePage.tsx
@@ -379,7 +379,7 @@ export function DriverProfilePage() {
   const resolvedTemplateId =
     checklistTemplateId && checklistTemplateId.trim().length
       ? checklistTemplateId.trim()
-      : 'best-food-checklist';
+      : '3dhaulage-checklist';
 
   const checklistMutation = useMutation({
     mutationFn: async (values: ChecklistFormValues) => {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -34,7 +34,7 @@ export function LoginPage() {
       </div>
       <div className="mx-auto w-full max-w-md rounded-3xl border border-white/10 bg-white/10 p-10 shadow-2xl backdrop-blur-xl">
         <div className="mb-8 text-center text-white">
-          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-white/80">3D Haulage</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.4em] text-white/80">3DHaulage</p>
           <h1 className="mt-3 text-3xl font-semibold">Panel logowania</h1>
           <p className="mt-2 text-sm text-white/70">
             Zaloguj się, aby zarządzać flotą i zleceniami w czasie rzeczywistym.

--- a/supabase/functions/generate-checklist-report/templates/3dhaulage-checklist.html
+++ b/supabase/functions/generate-checklist-report/templates/3dhaulage-checklist.html
@@ -127,7 +127,7 @@
     <div class="sheet">
       <header>
         <div>
-          <h1>3D Haulage</h1>
+          <h1>3DHaulage</h1>
           <span class="subtle">Driver Vehicle Check &amp; Defect Report</span>
         </div>
         <div style="text-align: right; font-size: 12px;">
@@ -234,7 +234,7 @@
       </div>
 
       <footer>
-        Raport wygenerowano automatycznie {{generatedAt}} przez system 3D Haulage.
+        Raport wygenerowano automatycznie {{generatedAt}} przez system 3DHaulage.
       </footer>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- rename the checklist PDF template to 3dhaulage-checklist and update the default identifier
- refresh driver- and login-facing chrome to display the 3DHaulage name consistently
- retitle the driver navigation entry to "Checklista" and document the new template id in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0141a79748324b6aa94b6e64615d7